### PR TITLE
Icons and empty labels support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See the [tests](/tests/test_py_d2) for more detailed usage examples.
 - [x] Shapes in shapes
 - [x] Arrow directions
 - [x] Markdown / block strings / code in shapes
-- [ ] Icons in shapes
+- [x] Icons in shapes
 - [ ] SQL table shapes
 - [ ] Class shapes
 - [ ] Comments

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ See the [tests](/tests/test_py_d2) for more detailed usage examples.
 - [x] Arrow directions
 - [x] Markdown / block strings / code in shapes
 - [x] Icons in shapes
+- [x] Support for empty labels
 - [ ] SQL table shapes
 - [ ] Class shapes
 - [ ] Comments

--- a/src/py_d2/helpers.py
+++ b/src/py_d2/helpers.py
@@ -13,10 +13,13 @@ def add_label_and_properties(
     has_properties: bool = properties is not None and len(properties) > 0
 
     first_line = name
-    if label or has_properties:
+    if label is not None or has_properties:
         first_line += ":"
 
-    if label:
+    if label is not None and len(label) == 0:
+        first_line += ' ""'
+
+    if label and len(label) > 0:
         first_line += f" {label}"
 
     if has_properties:

--- a/src/py_d2/shape.py
+++ b/src/py_d2/shape.py
@@ -72,6 +72,8 @@ class D2Shape:
         shapes: Optional[List[D2Shape]] = None,
         # The style of this shape
         style: Optional[D2Style] = None,
+        # An icon for this shape
+        icon: Optional[str] = None,
         # Connections for the child shapes (NOT the connections for this shape)
         connections: Optional[List[D2Connection]] = None,
         # A shape this is near
@@ -83,6 +85,7 @@ class D2Shape:
         self.shape = shape
         self.shapes = shapes or []
         self.style = style
+        self.icon = icon
         self.connections = connections or []
         self.near = near
         self.kwargs = kwargs
@@ -106,6 +109,9 @@ class D2Shape:
 
         if self.style:
             properties += self.style.lines()
+
+        if self.icon:
+            properties.append(f"icon: {self.icon}")
 
         for key, value in self.kwargs.items():
             other_property = value.lines()

--- a/tests/test_py_d2/test_d2_shape.py
+++ b/tests/test_py_d2/test_d2_shape.py
@@ -137,6 +137,11 @@ def test_d2_shape_shapes():
     assert str(shape_sequence_diagram) == "shape_name: {\n  shape: sequence_diagram\n}"
 
 
+def test_d2_shape_icon():
+    shape = D2Shape(name="shape_name", icon="https://icons.terrastruct.com/essentials%2F117-database.svg")
+    assert str(shape) == "shape_name: {\n  icon: https://icons.terrastruct.com/essentials%2F117-database.svg\n}"
+
+
 def test_d2_shape_near():
     shape = D2Shape(name="shape_name", near="some_other_shape")
     assert str(shape) == "shape_name: {\n  near: some_other_shape\n}"

--- a/tests/test_py_d2/test_d2_shape.py
+++ b/tests/test_py_d2/test_d2_shape.py
@@ -16,6 +16,11 @@ def test_d2_shape_label():
     assert str(shape) == "shape_name: shape_label"
 
 
+def test_d2_shape_empty_label():
+    shape = D2Shape(name="shape_name", label="")
+    assert str(shape) == 'shape_name: ""'
+
+
 def test_d2_shape_style():
     shape = D2Shape(name="shape_name", style=D2Style(fill="red"))
     assert str(shape) == "shape_name: {\n  style: {\n    fill: red\n  }\n}"


### PR DESCRIPTION
### Icons

For the icons support I added the property to the shape class.

shape = D2Shape(name="shape_name", icon="https://icons.terrastruct.com/essentials%2F117-database.svg")

![image](https://github.com/user-attachments/assets/fdd798c6-4f0c-4040-a42c-08ec52b375b8)

### Empty labels

For this feature I modified some of the code in the helper function, so it can detect empty strings for labels and return properly.

shape = D2Shape(name="shape_name", label="")

![image](https://github.com/user-attachments/assets/b61a77f8-92c9-4f08-84ad-365ff720afa4)



