### PR TITLE
Adds font-color and border-radius to D2Style

### DIFF
--- a/src/py_d2/style.py
+++ b/src/py_d2/style.py
@@ -19,6 +19,8 @@ class D2Style:
         opacity: Optional[float] = None,
         stroke_dash: Optional[int] = None,
         three_d: Optional[bool] = None,
+        font_color: Optional[str] = None,
+        border_radius: Optional[str] = None,
     ):
         self.stroke = stroke
         self.stroke_width = stroke_width
@@ -27,6 +29,8 @@ class D2Style:
         self.opacity = opacity
         self.stroke_dash = stroke_dash
         self.three_d = three_d
+        self.font_color = font_color
+        self.border_radius = border_radius
 
     def lines(self) -> List[str]:
         styles: List[str] = []
@@ -51,6 +55,12 @@ class D2Style:
 
         if self.three_d:
             styles.append(f"3d: {stringify_bool(self.three_d)}")
+
+        if self.font_color:
+            styles.append(f"font-color: {self.font_color}")
+
+        if self.border_radius:
+            styles.append(f"border-radius: {self.border_radius}")
 
         if len(styles) == 0:
             return []

--- a/tests/test_py_d2/test_d2_style.py
+++ b/tests/test_py_d2/test_d2_style.py
@@ -42,6 +42,19 @@ def test_d2_style_three_d():
     assert str(style) == "style: {\n  3d: true\n}"
 
 
+def test_d2_style_font_color():
+    style = D2Style(font_color="red")
+    assert str(style) == "style: {\n  font-color: red\n}"
+
+def test_d2_style_font_color_hex():
+    style = D2Style(font_color='"#274e13"')
+    assert str(style) == 'style: {\n  font-color: "#274e13"\n}'
+
+def test_d2_style_border_radius():
+    style = D2Style(border_radius="999")
+    assert str(style) == "style: {\n  border-radius: 999\n}"
+
+
 def test_d2_style_all():
     style = D2Style(
         stroke="red",
@@ -51,6 +64,8 @@ def test_d2_style_all():
         opacity=0.5,
         stroke_dash=2,
         three_d=True,
+        font_color='"#274e13"',
+        border_radius='999',
     )
     assert str(style) == "\n".join(
         [
@@ -62,6 +77,8 @@ def test_d2_style_all():
             "  opacity: 0.5",
             "  stroke-dash: 2",
             "  3d: true",
+            "  font-color: \"#274e13\"",
+            "  border-radius: 999",
             "}",
         ]
     )


### PR DESCRIPTION
This pull request adds support for `font-color` and `border-radius` within the `D2Style` class.  These additions allow users to further customize the appearance of their diagrams by controlling the font color and border radius of elements.

*Changes:*

- Added `font_color` (Optional[str]) and `border_radius` (Optional[str]) parameters to the `D2Style` constructor.
- Included tests for both attributes and added them to the all styles test

*Example Usage:*

```python
from py_d2.style import D2Style

style = D2Style(
    stroke="#0000FF",
    fill="#ADD8E6",
    font_color="red",  # New
    border_radius="10" # New
)

```